### PR TITLE
expect included module ActiveTriples::RDFSource instead of single inheritence from ActiveTriples::Resource, per ActiveTriples 0.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ script: "bundle exec rspec spec"
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.0
-  - 2.1.1
+  - 2.1.6
+  - 2.2.2
+  - ruby-head
   - jruby-19mode
 matrix:
   allow_failures:
-      - rvm: jruby-19mode
+    - rvm: ruby-head
+    - rvm: jruby-19mode

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 [![Coverage Status](https://coveralls.io/repos/ActiveTriples/active_triples-local_name/badge.png?branch=master)](https://coveralls.io/r/ActiveTriples/active_triples-local_name?branch=master)
 [![Gem Version](https://badge.fury.io/rb/active_triples-local_name.svg)](http://badge.fury.io/rb/active_triples-local_name)
 
-Provides utilities for working with local names under the [ActiveTriples](https://github.com/ActiveTriples/ActiveTriples) 
-framework.  Includes a default implementation of a local name minter.
+Provides utilities for working with local names under the [ActiveTriples](https://github.com/ActiveTriples/ActiveTriples) framework.  Includes a default implementation of a local name minter.
 
 
 ## Installation
@@ -43,7 +42,8 @@ ActiveTriples::Repositories.add_repository :default, RDF::Repository.new
 
 # create a DummyResource for ad-hoc testing
 # NOTE: local name minter requires resource class to have base_uri configured
-class DummyResourceWithBaseURI < ActiveTriples::Resource
+class DummyResourceWithBaseURI
+  include  ActiveTriples::RDFSource
   configure :base_uri => "http://example.org",
             :type => RDF::URI("http://example.org/SomeClass"),
             :repository => :default
@@ -60,15 +60,11 @@ localname = ActiveTriples::LocalName::Minter.generate_local_name(
 
 Parameter NOTES:
 * for_class = DummyResourceWithBaseURI - resource class must have base_uri configured
-* max_tries = 10 - If using default minter, it should easily find an available local name in 10 tries.  
-  If your minter algorithm gets lots of clashes with existing URIs and max_tries is set high, you may 
-  run into performance issues.
+* max_tries = 10 - If using default minter, it should easily find an available local name in 10 tries.
+  If your minter algorithm gets lots of clashes with existing URIs and max_tries is set high, you may run into performance issues.
 * minter_args (optional) = {:prefix=>'d'} - The default minter takes a single hash argument.  You can
   define minters that take no arguments, multiple arguments, or a multiple item hash argument.
-* minter_block = nil - When minter_block is not passed in, the default minter algorithm, which produces
-  a UUID, will be used.  Best practice is to start local names with an alpha character.  UUIDs generate 
-  with either an alpha or numeric as the first character. Passing in a prefix of 'd' forces the local 
-  name to start with the character 'd'.
+* minter_block = nil - When minter_block is not passed in, the default minter algorithm, which produces a UUID, will be used.  Best practice is to start local names with an alpha character.  UUIDs generate with either an alpha or numeric as the first character. Passing in a prefix of 'd' forces the local name to start with the character 'd'.
 
 
 #### Example: Passing in a block as minter

--- a/active_triples-local_name.gemspec
+++ b/active_triples-local_name.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license     = "APACHE2"
   s.required_ruby_version     = '>= 1.9.3'
 
-  s.add_dependency('active-triples', '~> 0.5')
+  s.add_dependency('active-triples', '~> 0.7')
 
   s.add_dependency('deprecation', '~> 0.1')
   s.add_dependency('activesupport', '>= 3.0.0')

--- a/active_triples-local_name.gemspec
+++ b/active_triples-local_name.gemspec
@@ -14,10 +14,10 @@ Gem::Specification.new do |s|
   s.license     = "APACHE2"
   s.required_ruby_version     = '>= 1.9.3'
 
-  s.add_dependency('active-triples', '~> 0.7')
+  s.add_dependency('active-triples')
 
-  s.add_dependency('deprecation', '~> 0.1')
-  s.add_dependency('activesupport', '>= 3.0.0')
+  s.add_dependency('deprecation')
+  s.add_dependency('activesupport')
 
   s.add_development_dependency('rdoc')
   s.add_development_dependency('rspec')

--- a/lib/active_triples/local_name/minter.rb
+++ b/lib/active_triples/local_name/minter.rb
@@ -10,7 +10,7 @@ module ActiveTriples
       # Generate a random localname that combined with a class' base_uri does not already exist in
       # registered triplestores.
       #
-      # @param [Class] the class inheriting from <tt>ActiveTriples::Reource</tt> whose configuration
+      # @param [Class] the class, which must include <tt>ActiveTriples::RDFSource</tt> module, whose configuration
       #   is used to generate the full URI for testing for uniqueness of the generated local name
       # @param [Integer] the maximum number of attempts to make a unique local name
       # @yieldparam the arguments to pass to the minter block (optional)
@@ -21,7 +21,7 @@ module ActiveTriples
       # @return [String] the generated local name
       #
       # @raise [ArgumentError] if maximum allowed tries is less than 0
-      # @raise [ArgumentError] if for_class does not inherit from ActiveTriples::Resources
+      # @raise [ArgumentError] if for_class does not include ActiveTriples::RDFSource module
       # @raise [ArgumentError] if minter_block is not a block (does not respond to call)
       # @raise [Exception] if for_class does not have base_uri configured
       # @raise [Exception] if an available local name is not found in the maximum allowed tries.
@@ -35,7 +35,7 @@ module ActiveTriples
       def self.generate_local_name(for_class, max_tries=10, *minter_args, &minter_block)
         raise ArgumentError, 'Argument max_tries must be >= 1 if passed in' if     max_tries    <= 0
 
-        raise ArgumentError, 'Argument for_class must inherit from ActiveTriples::Resource' unless for_class < ActiveTriples::Resource
+        raise ArgumentError, 'Argument for_class must include module ActiveTriples::RDFSource' unless for_class.included_modules.include?(ActiveTriples::RDFSource)
         raise 'Requires base_uri to be defined in for_class.' unless for_class.base_uri
 
         raise ArgumentError, 'Invalid minter_block.' if minter_block && !minter_block.respond_to?(:call)

--- a/lib/active_triples/local_name/version.rb
+++ b/lib/active_triples/local_name/version.rb
@@ -1,5 +1,5 @@
 module ActiveTriples
   module LocalName
-    VERSION = "0.7.0"
+    VERSION = "0.5.0"
   end
 end

--- a/lib/active_triples/local_name/version.rb
+++ b/lib/active_triples/local_name/version.rb
@@ -1,5 +1,5 @@
 module ActiveTriples
   module LocalName
-    VERSION = "0.5.0"
+    VERSION = "0.7.0"
   end
 end

--- a/spec/active_triples/local_name/minter_spec.rb
+++ b/spec/active_triples/local_name/minter_spec.rb
@@ -34,11 +34,13 @@ describe ActiveTriples::LocalName::Minter do
     subject {DummyResourceWithBaseURI.new('1')}
 
     before do
-      class DummyResource < ActiveTriples::Resource
+      class DummyResource
+        include  ActiveTriples::RDFSource
         configure :type => RDF::URI('http://example.org/SomeClass')
         property :title, :predicate => RDF::DC.title
       end
-      class DummyResourceWithBaseURI < ActiveTriples::Resource
+      class DummyResourceWithBaseURI
+        include  ActiveTriples::RDFSource
         configure :base_uri => "http://example.org",
                   :type => RDF::URI("http://example.org/SomeClass"),
                   :repository => :default
@@ -99,7 +101,7 @@ describe ActiveTriples::LocalName::Minter do
         end
       end
 
-      context "and class doesn't inherit from ActiveTriples::Resource" do
+      context "and class doesn't include module ActiveTriples::RDFSource" do
         before do
           class DummyNonResource
           end
@@ -110,7 +112,7 @@ describe ActiveTriples::LocalName::Minter do
 
         it "should raise error" do
           expect{ ActiveTriples::LocalName::Minter.generate_local_name(DummyNonResource) }.
-              to raise_error(ArgumentError, 'Argument for_class must inherit from ActiveTriples::Resource')
+              to raise_error(ArgumentError, 'Argument for_class must include module ActiveTriples::RDFSource')
         end
       end
 


### PR DESCRIPTION
@elrayle   it would be awesome if you merged this and cut a new release of active_triples-local_name ASAP.

This was the motivation for my changes:  https://github.com/ActiveTriples/ActiveTriples/blob/develop/CHANGES.md

I'm trying to create a PR for open_annotation_rdf for more recent active-triples and rdf gems, and this dependency is a part of that.

Note that we've tried to avoid having pinned gem versions;  if you prefer pinned, I think ~> 0.7.0 or ~> 0.8.1 will both work fine.  :smile: 
